### PR TITLE
Add Twig (HTML) Support

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -17,7 +17,7 @@ exists(outputDir, function (exists) {
     mkdirSync(outputDir);
   }
   writeSnippets("css", ".source.css, .source.sass", "content: '\\\\", "';");
-  writeSnippets("html", ".text.html", "&#x", ";");
+  writeSnippets("html", ".text.html .source.html.twig", "&#x", ";");
   writeSnippets("javascript", ".source.coffee, .source.js, .source.json, .source.livescript, .source.ts", "\\\\u{", "}");
   writeSnippets("python", ".source.python", "\\\\U", "");
   writeSnippets("ruby", ".source.ruby", "\\\\u{", "}");

--- a/src/build.js
+++ b/src/build.js
@@ -17,7 +17,7 @@ exists(outputDir, function (exists) {
     mkdirSync(outputDir);
   }
   writeSnippets("css", ".source.css, .source.sass", "content: '\\\\", "';");
-  writeSnippets("html", ".text.html .source.html.twig", "&#x", ";");
+  writeSnippets("html", ".text.html, .source.html.twig", "&#x", ";");
   writeSnippets("javascript", ".source.coffee, .source.js, .source.json, .source.livescript, .source.ts", "\\\\u{", "}");
   writeSnippets("python", ".source.python", "\\\\U", "");
   writeSnippets("ruby", ".source.ruby", "\\\\u{", "}");


### PR DESCRIPTION
closes #1

Followed Symfony framework defaults for Twig2: https://symfony.com/doc/current/templating.html

**Note:**
I didn't know whether to add a new `writeSnippets()` instance or not, so I just added it to the `html` one as Twig2-HTML templates don't change from standard HTML.