### PR TITLE
Support Github Flavored Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Snippets to insert escaped Emoji code into a variety of languages, including:
 - Ruby
 - Twig
 - TypeScript
+- Github Flavored Markdown :wave:
+
+Note Github supports emojis out of the box (e.g. `:wave:`), so there is no need to paste Unicode characters.
 
 This package is also available for [Sublime Text](https://github.com/idleberg/sublime-emoji-code) and [Visual Studio Code](https://github.com/idleberg/vscode-emoji-code).
 

--- a/src/build.js
+++ b/src/build.js
@@ -21,6 +21,7 @@ exists(outputDir, function (exists) {
   writeSnippets("javascript", ".source.coffee, .source.js, .source.json, .source.livescript, .source.ts", "\\\\u{", "}");
   writeSnippets("python", ".source.python", "\\\\U", "");
   writeSnippets("ruby", ".source.ruby", "\\\\u{", "}");
+  writeSnippets("markdown", ".source.gfm", "&#x", ";");
 });
 
 // Functions


### PR DESCRIPTION
Markdown compiles to HTML, so supporting markdown only requires returning the correct HTML escape sequence.

Sources:
https://spec.commonmark.org/0.29/#entity-and-numeric-character-references
https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md